### PR TITLE
feat(#49)!: make max_code_length optional in metaphone and double metaphone

### DIFF
--- a/src/daitch_mokotoff.rs
+++ b/src/daitch_mokotoff.rs
@@ -138,7 +138,7 @@ impl TryFrom<(&str, &str, &str, &str)> for Rule {
 ///     * `Replacement_before_vowel`: the code to replace `pattern` with if `pattern` is before a vowel inside the word.
 ///     * `default_replacement`: the code to replace `pattern` with for other cases.
 ///
-/// To support branching, any pattern can be in the form of `code|code|...`.
+///   To support branching, any pattern can be in the form of `code|code|...`.
 ///
 /// Rules are separated by `\n`.
 ///

--- a/src/soundex.rs
+++ b/src/soundex.rs
@@ -86,7 +86,8 @@ impl Soundex {
     ///
     /// * `mapping`: mapping array.
     ///   It contains for each letter its corresponding code.
-    ///   Index 0 is the code for `A`, index is for `B` and so on for each letter of the latin alphabet.
+    ///   Index 0 is the code for `A`, index is for `B` and so on for
+    ///   each letter of the latin alphabet.
     ///   Code `-` is treated as silent (eg [DEFAULT_US_ENGLISH_GENEALOGY_MAPPING_SOUNDEX]).
     /// * `special_case_h_w`: a boolean to indicate that `H` and `W` should be treated as silence.
     pub fn new(mapping: [char; 26], special_case_h_w: bool) -> Self {


### PR DESCRIPTION
`max_code_length`  is now optional for metaphone and double metaphone algorithms.

- [x] Add unit tests

Closes #49 