### PR TITLE
Fix Metaphone region_match matching unanchored instead of at the index

### DIFF
--- a/src/metaphone.rs
+++ b/src/metaphone.rs
@@ -65,7 +65,7 @@ impl Metaphone {
     }
 
     fn region_match(text: &str, index: usize, test: &str) -> bool {
-        index + test.len() - 1 < text.len() && text[index..].contains(test)
+        index + test.len() - 1 < text.len() && text[index..].starts_with(test)
     }
 
     fn is_last_char(wdsz: usize, n: usize) -> bool {
@@ -570,6 +570,19 @@ mod tests {
         assert_eq!(metaphone.encode("SCIENCE"), "SNS");
         assert_eq!(metaphone.encode("SCENE"), "SN");
         assert_eq!(metaphone.encode("SCY"), "S");
+    }
+
+    #[test]
+    fn test_region_match_is_anchored() {
+        // region_match must match the test string AT the given index, not
+        // anywhere in the remaining slice. An unanchored `contains` let a
+        // later "SH" wrongly trigger the X sound on an earlier plain S.
+        let metaphone = Metaphone::default();
+
+        // The leading S is not followed by H, so it stays S; only the trailing
+        // SH becomes X. commons-codec reference: "SX".
+        assert_eq!(metaphone.encode("SASH"), "SX");
+        assert_eq!(metaphone.encode("SASHA"), "SX");
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`Metaphone::region_match(text, index, test)` is meant to test whether `test` occurs **at** `index` -- it ports commons-codec's `inwd.substring(i, i + test.length()).equals(test)`. But it uses:

```rust
index + test.len() - 1 < text.len() && text[index..].contains(test)
```

`contains` is **unanchored**: it returns `true` when `test` occurs *anywhere* in the remaining slice, not only at `index`. Since `region_match` is used for the `CIA` / `GN` / `SH` / `SIO` / `SIA` / `TIA` / `TIO` rules, a later occurrence of one of those wrongly triggers the rule on an earlier position:

```rust
Metaphone::default().encode("SASH")   // "XX", should be "SX"
Metaphone::default().encode("SASHA")  // "XX", should be "SX"
```

The leading `S` is not followed by `H`, so it should stay `S`; but `"SH"` occurs later at index 2, so the unanchored `contains` fires the `X` sound on the first `S`. The reference Apache commons-codec `Metaphone` returns `SX`.

## Fix
Use `starts_with(test)` so the match is anchored at the index:

```rust
index + test.len() - 1 < text.len() && text[index..].starts_with(test)
```

This restores the documented commons-codec contract.

## Testing
- Added `test_region_match_is_anchored` asserting `encode("SASH") == "SX"` and `encode("SASHA") == "SX"`.
- Red/green: before the change the test fails (`"XX"` vs `"SX"`); after it passes.
- `cargo test --all-features` -> 286 passed, 0 failed; `cargo fmt --check` clean; no new clippy warnings.

There is no existing issue for this; it surfaced while comparing outputs against commons-codec. Happy to adjust if you would prefer an issue first.

---
This change was prepared with AI assistance and reviewed by me before submission.